### PR TITLE
Upgrade to bytes 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/bufsize"
 readme = "README.md"
 
 [dependencies]
-bytes = "0.6"
+bytes = "1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ unsafe impl BufMut for SizeCounter {
         let _ = cnt;
     }
 
-    fn bytes_mut(&mut self) -> &mut UninitSlice {
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
         unimplemented!("SizeCounter doesn't really have a buffer")
     }
 


### PR DESCRIPTION
- Release notes: https://github.com/tokio-rs/bytes/releases/tag/v1.0.0
- API documentation: https://docs.rs/bytes/1.0.0/bytes/