### PR TITLE
Unconditionally turn off bytes/std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.39"
 
 [features]
 default = ["std"]
-std = ["bytes/std"]
+std = []
 
 [dependencies]
 bytes = { version = "1.0", default-features = false }


### PR DESCRIPTION
`feature = "std"` doesn't impact the definition of `bytes::BufMut`. It's mostly just adding `Buf`/`BufMut` impls for standard library types.